### PR TITLE
Create a Secret with PAT for backport

### DIFF
--- a/otterdog/eclipse-tycho.jsonnet
+++ b/otterdog/eclipse-tycho.jsonnet
@@ -66,6 +66,9 @@ orgs.newOrg('eclipse-tycho') {
         orgs.newRepoSecret('TYCHO_SITE_PAT') {
           value: "********",
         },
+        orgs.newRepoSecret('TYCHO_BACKPORT_PAT') {
+          value: "********",
+        },
       ],
       rulesets: [
         orgs.newRepoRuleset('release-branches') {


### PR DESCRIPTION
We like to have a PAT for the backports action, I created a Helpdesk ticket here as I susspect it won'T be enough to edit the otterdog file here:
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4273